### PR TITLE
Add SQLModel models and initial Alembic migration

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,41 @@
+from logging.config import fileConfig
+from alembic import context
+
+from app.db import engine
+from app.models import SQLModel
+
+config = context.config
+fileConfig(config.config_file_name)
+target_metadata = SQLModel.metadata
+
+def run_migrations_offline() -> None:
+    url = str(engine.url)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def run_migrations() -> None:
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+if __name__ == "__main__":
+    run_migrations()

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,62 @@
+"""initial schema
+
+Revision ID: 0001_initial
+Revises: 
+Create Date: 2024-05-30
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "calendars",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("access_token", sa.String(), nullable=False),
+        sa.Column("refresh_token", sa.String(), nullable=True),
+        sa.Column("last_synced", sa.DateTime(), nullable=True),
+    )
+
+    op.create_table(
+        "tasks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("due_datetime", sa.DateTime(), nullable=True),
+        sa.Column(
+            "priority",
+            sa.Enum("low", "medium", "high", name="taskpriority"),
+            nullable=False,
+        ),
+        sa.Column("calendar_event_id", sa.String(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "in_progress", "completed", name="taskstatus"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+def downgrade() -> None:
+    op.drop_table("tasks")
+    op.drop_table("calendars")
+    op.drop_table("users")
+    op.execute("DROP TYPE IF EXISTS taskpriority")
+    op.execute("DROP TYPE IF EXISTS taskstatus")

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,18 @@
+import os
+from sqlmodel import SQLModel, create_engine
+
+DB_USER = os.getenv("DB_USER", "postgres")
+DB_PASSWORD = os.getenv("DB_PASSWORD", "postgres")
+DB_NAME = os.getenv("DB_NAME", "taskmuse")
+DB_HOST = os.getenv("DB_HOST", "db")
+DB_PORT = os.getenv("DB_PORT", "5432")
+
+DATABASE_URL = (
+    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)
+
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlmodel import SQLModel, Field
+
+
+class TaskPriority(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class TaskStatus(str, Enum):
+    pending = "pending"
+    in_progress = "in_progress"
+    completed = "completed"
+
+
+class User(SQLModel, table=True):
+    __tablename__ = "users"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    email: str = Field(nullable=False, index=True, sa_column_kwargs={"unique": True})
+    hashed_password: str
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Calendar(SQLModel, table=True):
+    __tablename__ = "calendars"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: UUID = Field(foreign_key="users.id", nullable=False)
+    provider: str
+    access_token: str
+    refresh_token: Optional[str] = None
+    last_synced: Optional[datetime] = None
+
+
+class Task(SQLModel, table=True):
+    __tablename__ = "tasks"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: UUID = Field(foreign_key="users.id", nullable=False)
+    title: str
+    description: Optional[str] = None
+    due_datetime: Optional[datetime] = None
+    priority: TaskPriority = Field(
+        default=TaskPriority.medium,
+        sa_column=sa.Column(sa.Enum(TaskPriority, name="taskpriority")),
+    )
+    calendar_event_id: Optional[str] = None
+    status: TaskStatus = Field(
+        default=TaskStatus.pending,
+        sa_column=sa.Column(sa.Enum(TaskStatus, name="taskstatus")),
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 fastapi = "^0.110"
 uvicorn = {extras = ["standard"], version = "^0.28"}
 psycopg2-binary = "^2.9"
+sqlmodel = "^0.0.16"
+alembic = "^1.12"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"


### PR DESCRIPTION
## Summary
- define SQLModel models for users, calendars, and tasks
- setup database connection utilities
- add Alembic configuration with initial migration
- update poetry config with sqlmodel and alembic dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*