### PR TITLE
Implement basic auth and Google callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Monorepo for the TaskMuse project. It contains the backend API and the React Nat
 └── .env.example
 ```
 
-The backend exposes a `/healthz` endpoint for health checks.
+The backend exposes a `/healthz` endpoint for health checks and simple
+authentication routes under `/auth`.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,122 @@
-from fastapi import FastAPI
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
 
 app = FastAPI()
+
+USERS: Dict[str, Dict[str, Any]] = {}
+CALENDARS: Dict[str, Dict[str, Any]] = {}
+
+SECRET_KEY = "secret"
+ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+REFRESH_TOKEN_EXPIRE_SECONDS = 86400 * 7
+
+
+class UserSchema(BaseModel):
+    email: str
+    password: str
+
+
+class TokenSchema(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class OAuthCodeSchema(BaseModel):
+    code: str
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return hash_password(password) == hashed
+
+
+def _jwt_encode(payload: Dict[str, Any]) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    h_b64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    p_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    msg = f"{h_b64}.{p_b64}".encode()
+    sig = base64.urlsafe_b64encode(hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).digest()).decode().rstrip("=")
+    return f"{h_b64}.{p_b64}.{sig}"
+
+
+def create_access_token(data: Dict[str, Any], expires_seconds: int) -> str:
+    payload = data.copy()
+    payload["exp"] = int(time.time()) + expires_seconds
+    return _jwt_encode(payload)
+
+
+def decode_token(token: str) -> Dict[str, Any]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("invalid token")
+    h_b64, p_b64, sig = parts
+    msg = f"{h_b64}.{p_b64}".encode()
+    expected = base64.urlsafe_b64encode(hmac.new(SECRET_KEY.encode(), msg, hashlib.sha256).digest()).decode().rstrip("=")
+    if not hmac.compare_digest(expected, sig):
+        raise ValueError("invalid signature")
+    payload_json = base64.urlsafe_b64decode(p_b64 + "=" * (-len(p_b64) % 4))
+    payload = json.loads(payload_json)
+    if payload.get("exp", 0) < int(time.time()):
+        raise ValueError("expired")
+    return payload
 
 @app.get('/healthz')
 async def healthz():
     return {'status': 'ok'}
+
+
+@app.middleware('http')
+async def inject_user(request: Request, call_next):
+    request.state.user = None
+    auth = request.headers.get('Authorization')
+    if auth and auth.startswith('Bearer '):
+        token = auth.split(' ')[1]
+        try:
+            payload = decode_token(token)
+            request.state.user = USERS.get(payload.get('sub'))
+        except Exception:
+            request.state.user = None
+    response = await call_next(request)
+    return response
+
+
+@app.post('/auth/register')
+async def register(user: UserSchema):
+    if user.email in USERS:
+        raise HTTPException(status_code=400, detail='User already exists')
+    USERS[user.email] = {
+        'id': len(USERS) + 1,
+        'email': user.email,
+        'password': hash_password(user.password),
+    }
+    return {'email': user.email}
+
+
+@app.post('/auth/login', response_model=TokenSchema)
+async def login(user: UserSchema):
+    stored = USERS.get(user.email)
+    if not stored or not verify_password(user.password, stored['password']):
+        raise HTTPException(status_code=401, detail='Invalid credentials')
+    access = create_access_token({'sub': user.email}, ACCESS_TOKEN_EXPIRE_SECONDS)
+    refresh = create_access_token({'sub': user.email, 'refresh': True}, REFRESH_TOKEN_EXPIRE_SECONDS)
+    return {'access_token': access, 'refresh_token': refresh, 'token_type': 'bearer'}
+
+
+@app.post('/auth/google/callback')
+async def google_callback(data: OAuthCodeSchema, request: Request):
+    user = request.state.user
+    if not user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    CALENDARS[user['email']] = {'token': data.code}
+    return {'status': 'stored'}

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_register_and_login():
+    resp = client.post('/auth/register', json={'email': 'user@example.com', 'password': 'secret'})
+    assert resp.status_code == 200
+    resp = client.post('/auth/login', json={'email': 'user@example.com', 'password': 'secret'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'access_token' in data and 'refresh_token' in data
+    auth = {'Authorization': f"Bearer {data['access_token']}"}
+    resp = client.post('/auth/google/callback', json={'code': 'abc'}, headers=auth)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- implement register/login with JWT-like tokens
- add Google OAuth callback and middleware to inject current user
- test auth flow
- document new auth routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*