### PR TITLE
Add unified API routers and health endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,33 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routers import auth, tasks
 
 app = FastAPI()
 
-@app.get('/healthz')
+# CORS for mobile app
+origins = [
+    "http://localhost:19006",
+    "http://localhost:19000",
+]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Global exception handler
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+# Routers mounted under /api/v1
+app.include_router(auth.router, prefix="/api/v1")
+app.include_router(tasks.router, prefix="/api/v1")
+
+@app.get('/api/v1/healthz')
 async def healthz():
     return {'status': 'ok'}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post('/login')
+async def login():
+    return {"message": "login"}

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get('/tasks')
+async def list_tasks():
+    return []

--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -4,6 +4,6 @@ from app.main import app
 client = TestClient(app)
 
 def test_healthz():
-    response = client.get('/healthz')
+    response = client.get('/api/v1/healthz')
     assert response.status_code == 200
     assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- set up API entrypoint with CORS and global error handler
- add auth and tasks routers
- mount routers under `/api/v1`
- update healthcheck path and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*