### PR TITLE
Add Expo Router mobile skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ Monorepo for the TaskMuse project. It contains the backend API and the React Nat
 .
 ├── backend        # FastAPI application
 ├── mobile         # React Native app (Expo)
+│   ├── app                # Expo Router screens
+│   └── src/context        # Shared React contexts
 ├── scripts        # Helper scripts
 ├── docker-compose.yml
 └── .env.example
 ```
 
-The backend exposes a `/healthz` endpoint for health checks.
+The backend exposes a `/healthz` endpoint for health checks. The mobile app uses
+Expo Router with Login, Register, Home, Task Details and Voice Capture screens.
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,10 @@
+import { Slot } from 'expo-router';
+import { AuthProvider } from './src/context/AuthContext';
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Slot />
+    </AuthProvider>
+  );
+}

--- a/mobile/app/(app)/_layout.tsx
+++ b/mobile/app/(app)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function AppLayout() {
+  return <Stack />;
+}

--- a/mobile/app/(app)/index.tsx
+++ b/mobile/app/(app)/index.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function Home() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Home Screen</Text>
+    </View>
+  );
+}

--- a/mobile/app/(app)/task/[id].tsx
+++ b/mobile/app/(app)/task/[id].tsx
@@ -1,0 +1,11 @@
+import { Text, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function TaskDetails() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Task Details {id}</Text>
+    </View>
+  );
+}

--- a/mobile/app/(app)/voice-capture.tsx
+++ b/mobile/app/(app)/voice-capture.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function VoiceCapture() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Voice Capture Screen</Text>
+    </View>
+  );
+}

--- a/mobile/app/(auth)/_layout.tsx
+++ b/mobile/app/(auth)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function AuthLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function Login() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Login Screen</Text>
+    </View>
+  );
+}

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+
+export default function Register() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Register Screen</Text>
+    </View>
+  );
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,0 +1,20 @@
+import { Slot, useRouter, useSegments } from 'expo-router';
+import { useEffect } from 'react';
+import { useAuth } from '../src/context/AuthContext';
+
+export default function RootLayout() {
+  const { token } = useAuth();
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    const inAuthGroup = segments[0] === '(auth)';
+    if (!token && !inAuthGroup) {
+      router.replace('/(auth)/login');
+    } else if (token && inAuthGroup) {
+      router.replace('/');
+    }
+  }, [token, segments]);
+
+  return <Slot />;
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "taskmuse-mobile",
+  "version": "0.1.0",
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "expo-router": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "jest": "^29.0.0",
+    "react-test-renderer": "18.2.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/mobile/src/context/AuthContext.tsx
+++ b/mobile/src/context/AuthContext.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string) => Promise<void>;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  token: null,
+  signIn: async () => {},
+  register: async () => {},
+  signOut: () => {},
+});
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(null);
+
+  const signIn = async (email: string, password: string) => {
+    const res = await fetch(`${API_URL}/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.access_token);
+    }
+  };
+
+  const register = async (email: string, password: string) => {
+    const res = await fetch(`${API_URL}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.access_token);
+    }
+  };
+
+  const refresh = async () => {
+    if (!token) return;
+    const res = await fetch(`${API_URL}/refresh`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setToken(data.access_token);
+    }
+  };
+
+  useEffect(() => {
+    const id = setInterval(refresh, 10 * 60 * 1000);
+    return () => clearInterval(id);
+  }, [token]);
+
+  const signOut = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{ token, signIn, register, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Expo Router structure for the mobile client
- create auth context with automatic token refresh
- wire navigation in `App.tsx`
- document the new mobile directory layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*