### PR TITLE
Add push notification infrastructure

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,15 @@
+import os
+from celery import Celery
+
+celery_app = Celery(
+    'taskmuse',
+    broker=os.environ.get('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
+    backend=os.environ.get('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0')
+)
+
+celery_app.conf.beat_schedule = {
+    'send-due-task-notifications': {
+        'task': 'app.tasks.send_due_task_notifications',
+        'schedule': 60.0,  # every minute
+    }
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,21 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .storage import push_tokens
 
 app = FastAPI()
 
 @app.get('/healthz')
 async def healthz():
     return {'status': 'ok'}
+
+
+class PushTokenIn(BaseModel):
+    user_id: str
+    token: str
+
+
+@app.post('/users/push-token')
+async def save_push_token(data: PushTokenIn):
+    push_tokens[data.user_id] = data.token
+    return {'status': 'saved'}

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,5 @@
+# In-memory storage for push tokens and tasks
+
+push_tokens: dict[str, str] = {}
+# Example task: {'user_id': '1', 'title': 'Finish report', 'due': datetime}
+tasks: list[dict] = []

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timedelta
+import os
+import requests
+
+from .celery_app import celery_app
+from .storage import push_tokens, tasks
+
+EXPO_PUSH_URL = os.environ.get('EXPO_PUSH_URL', 'https://exp.host/--/api/v2/push/send')
+
+@celery_app.task
+def send_due_task_notifications():
+    now = datetime.utcnow()
+    upcoming = now + timedelta(minutes=30)
+    count = 0
+    for task in tasks:
+        due = task.get('due')
+        if due and now <= due <= upcoming:
+            token = push_tokens.get(task.get('user_id'))
+            if token:
+                requests.post(EXPO_PUSH_URL, json={
+                    'to': token,
+                    'title': 'Task Reminder',
+                    'body': task.get('title', '')
+                })
+                count += 1
+    return count

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 fastapi = "^0.110"
 uvicorn = {extras = ["standard"], version = "^0.28"}
 psycopg2-binary = "^2.9"
+celery = "^5.3"
+requests = "^2.31"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/backend/tests/test_push_token.py
+++ b/backend/tests/test_push_token.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app import storage
+
+client = TestClient(app)
+
+
+def test_save_push_token():
+    response = client.post('/users/push-token', json={'user_id': '1', 'token': 'ExpoPushToken[test]'} )
+    assert response.status_code == 200
+    assert storage.push_tokens['1'] == 'ExpoPushToken[test]'

--- a/mobile/hooks/usePushToken.ts
+++ b/mobile/hooks/usePushToken.ts
@@ -1,0 +1,23 @@
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
+
+export async function registerPushToken(apiUrl: string, userId: string) {
+  if (!Constants.isDevice) {
+    return;
+  }
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== 'granted') {
+    return;
+  }
+  const tokenData = await Notifications.getExpoPushTokenAsync();
+  await fetch(`${apiUrl}/users/push-token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, token: tokenData.data }),
+  });
+}


### PR DESCRIPTION
## Summary
- support saving Expo push tokens on the backend
- configure Celery with beat schedule and notification task
- add Expo hook on the mobile client to register push token
- cover the new endpoint with a test

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*