### PR TITLE
Add API router mounting and CORS

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -5,12 +5,12 @@ client = TestClient(app)
 
 
 def test_register_and_login():
-    resp = client.post('/auth/register', json={'email': 'user@example.com', 'password': 'secret'})
+    resp = client.post('/api/v1/auth/register', json={'email': 'user@example.com', 'password': 'secret'})
     assert resp.status_code == 200
-    resp = client.post('/auth/login', json={'email': 'user@example.com', 'password': 'secret'})
+    resp = client.post('/api/v1/auth/login', json={'email': 'user@example.com', 'password': 'secret'})
     assert resp.status_code == 200
     data = resp.json()
     assert 'access_token' in data and 'refresh_token' in data
     auth = {'Authorization': f"Bearer {data['access_token']}"}
-    resp = client.post('/auth/google/callback', json={'code': 'abc'}, headers=auth)
+    resp = client.post('/api/v1/auth/google/callback', json={'code': 'abc'}, headers=auth)
     assert resp.status_code == 200

--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -4,6 +4,6 @@ from app.main import app
 client = TestClient(app)
 
 def test_healthz():
-    response = client.get('/healthz')
+    response = client.get('/api/v1/healthz')
     assert response.status_code == 200
     assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- mount routers under `/api/v1`
- enable CORS for mobile clients
- install global exception handler
- update tests for new base path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*