### PR TITLE
Add initial mobile navigation with Expo Router

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,15 @@
+import { registerRootComponent } from 'expo';
+import { ExpoRoot } from 'expo-router';
+import React from 'react';
+import AuthProvider from './AuthContext';
+
+export function App() {
+  const ctx = require('./app/_layout').default;
+  return (
+    <AuthProvider>
+      <ExpoRoot Component={ctx} />
+    </AuthProvider>
+  );
+}
+
+registerRootComponent(App);

--- a/mobile/AuthContext.tsx
+++ b/mobile/AuthContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import * as SecureStore from 'expo-secure-store';
+
+interface AuthContextType {
+  token: string | null;
+  login: (t: string) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  token: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await SecureStore.getItemAsync('jwt');
+      if (stored) {
+        setToken(stored);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (token) {
+      SecureStore.setItemAsync('jwt', token);
+    } else {
+      SecureStore.deleteItemAsync('jwt');
+    }
+  }, [token]);
+
+  const value = {
+    token,
+    login: (t: string) => setToken(t),
+    logout: () => setToken(null),
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function RootLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="login" options={{ headerShown: false }} />
+      <Stack.Screen name="register" options={{ title: 'Register' }} />
+      <Stack.Screen name="index" options={{ title: 'Home' }} />
+      <Stack.Screen name="task/[id]" options={{ title: 'Task Details' }} />
+      <Stack.Screen name="voice-capture" options={{ title: 'Voice Capture' }} />
+    </Stack>
+  );
+}

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Home from '../screens/Home';
+
+export default function Index() {
+  return <Home />;
+}

--- a/mobile/app/login.tsx
+++ b/mobile/app/login.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useContext } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { AuthContext } from '../AuthContext';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const { login } = useContext(AuthContext);
+
+  const handleLogin = async () => {
+    try {
+      const res = await fetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await res.json();
+      if (data.token) {
+        login(data.token);
+      }
+    } catch (err) {
+      // ignore
+    }
+  };
+
+  return (
+    <View style={{ padding: 16 }}>
+      <TextInput placeholder="Username" value={username} onChangeText={setUsername} style={{ marginBottom: 8 }} />
+      <TextInput placeholder="Password" value={password} onChangeText={setPassword} secureTextEntry style={{ marginBottom: 16 }} />
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+}

--- a/mobile/app/register.tsx
+++ b/mobile/app/register.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+
+export default function Register() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleRegister = async () => {
+    try {
+      await fetch('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+    } catch (err) {
+      // ignore
+    }
+  };
+
+  return (
+    <View style={{ padding: 16 }}>
+      <TextInput placeholder="Username" value={username} onChangeText={setUsername} style={{ marginBottom: 8 }} />
+      <TextInput placeholder="Password" value={password} onChangeText={setPassword} secureTextEntry style={{ marginBottom: 16 }} />
+      <Button title="Register" onPress={handleRegister} />
+    </View>
+  );
+}

--- a/mobile/app/task/[id].tsx
+++ b/mobile/app/task/[id].tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function TaskDetails() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  return (
+    <View style={{ padding: 16 }}>
+      <Text>Task ID: {id}</Text>
+    </View>
+  );
+}

--- a/mobile/app/voice-capture.tsx
+++ b/mobile/app/voice-capture.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import VoiceCapture from '../screens/VoiceCapture';
+
+export default function VoiceCapturePage() {
+  return <VoiceCapture />;
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "expo-router": "^3.0.0",
     "expo-speech": "^10.1.0",
     "react-native-voice": "^1.1.10"
   }


### PR DESCRIPTION
## Summary
- set up Expo Router navigation
- create Auth context for JWT storage
- add login, register, home, task details, and voice capture pages
- configure Babel for expo-router
- update package.json with expo dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*