### PR TITLE
Add theme and tabs

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,12 +2,15 @@ import { registerRootComponent } from 'expo';
 import { ExpoRoot } from 'expo-router';
 import React from 'react';
 import AuthProvider from './AuthContext';
+import { ThemeProvider } from './ui';
 
 export function App() {
   const ctx = require('./app/_layout').default;
   return (
     <AuthProvider>
-      <ExpoRoot Component={ctx} />
+      <ThemeProvider>
+        <ExpoRoot Component={ctx} />
+      </ThemeProvider>
     </AuthProvider>
   );
 }

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Tabs } from 'expo-router';
+import React from 'react';
+
+export default function TabLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen name="index" options={{ title: 'Agenda' }} />
+      <Tabs.Screen name="inbox" options={{ title: 'Inbox' }} />
+      <Tabs.Screen name="analytics" options={{ title: 'Analytics' }} />
+      <Tabs.Screen name="settings" options={{ title: 'Settings' }} />
+    </Tabs>
+  );
+}

--- a/mobile/app/(tabs)/analytics.tsx
+++ b/mobile/app/(tabs)/analytics.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function Analytics() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Analytics</Text>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/inbox.tsx
+++ b/mobile/app/(tabs)/inbox.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function Inbox() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Inbox</Text>
+    </View>
+  );
+}

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import Home from '../../screens/Home';
+
+export default function Agenda() {
+  return <Home />;
+}

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function Settings() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Settings</Text>
+    </View>
+  );
+}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -6,7 +6,8 @@ export default function RootLayout() {
     <Stack>
       <Stack.Screen name="login" options={{ headerShown: false }} />
       <Stack.Screen name="register" options={{ title: 'Register' }} />
-      <Stack.Screen name="index" options={{ title: 'Home' }} />
+      <Stack.Screen name="onboarding" options={{ headerShown: false }} />
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="task/[id]" options={{ title: 'Task Details' }} />
       <Stack.Screen name="voice-capture" options={{ title: 'Voice Capture' }} />
     </Stack>

--- a/mobile/app/onboarding/_layout.tsx
+++ b/mobile/app/onboarding/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from 'expo-router';
+import React from 'react';
+
+export default function OnboardingLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="first" options={{ headerShown: false }} />
+      <Stack.Screen name="second" options={{ headerShown: false }} />
+      <Stack.Screen name="third" options={{ headerShown: false }} />
+    </Stack>
+  );
+}

--- a/mobile/app/onboarding/first.tsx
+++ b/mobile/app/onboarding/first.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function OnboardingFirst() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Welcome to TaskMuse</Text>
+    </View>
+  );
+}

--- a/mobile/app/onboarding/second.tsx
+++ b/mobile/app/onboarding/second.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function OnboardingSecond() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Manage tasks and calendar effortlessly.</Text>
+    </View>
+  );
+}

--- a/mobile/app/onboarding/third.tsx
+++ b/mobile/app/onboarding/third.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function OnboardingThird() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Get started now!</Text>
+    </View>
+  );
+}

--- a/mobile/app/task/[id].tsx
+++ b/mobile/app/task/[id].tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { Button, useTheme } from '../../ui';
 import { useLocalSearchParams } from 'expo-router';
 
 export default function TaskDetails() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors } = useTheme();
   return (
-    <View style={{ padding: 16 }}>
-      <Text>Task ID: {id}</Text>
+    <View style={{ padding: 16, backgroundColor: colors.background, flex: 1 }}>
+      <Text style={{ color: colors.text }}>Task ID: {id}</Text>
+      <Button title="Complete" onPress={() => {}} />
     </View>
   );
 }

--- a/mobile/screens/Home.tsx
+++ b/mobile/screens/Home.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { useTheme } from '../ui';
 import Calendar from 'react-native-big-calendar';
 import { getTasks, getEvents, Task, CalendarEvent } from '../api/apiClient';
 
@@ -24,6 +25,7 @@ const priorityColor = (priority: Task['priority']): string => {
 export default function Home() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [events, setEvents] = useState<CombinedEvent[]>([]);
+  const { colors } = useTheme();
 
   useEffect(() => {
     async function loadData() {
@@ -52,14 +54,14 @@ export default function Home() {
   }, []);
 
   const renderTask = ({ item }: { item: Task }) => (
-    <View style={styles.taskItem}>
+    <View style={[styles.taskItem, { borderColor: colors.card }]}>
       <Text style={[styles.taskTitle, { color: priorityColor(item.priority) }]}>{item.title}</Text>
-      <Text style={styles.date}>{new Date(item.dueDate).toLocaleDateString()}</Text>
+      <Text style={[styles.date, { color: colors.text }]}>{new Date(item.dueDate).toLocaleDateString()}</Text>
     </View>
   );
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: colors.background }}>
       <Calendar events={events} height={400} />
       <FlatList
         data={tasks}
@@ -74,7 +76,6 @@ const styles = StyleSheet.create({
   taskItem: {
     padding: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#ccc',
   },
   taskTitle: {
     fontSize: 16,
@@ -82,6 +83,5 @@ const styles = StyleSheet.create({
   },
   date: {
     fontSize: 12,
-    color: '#555',
   },
 });

--- a/mobile/ui/Button.tsx
+++ b/mobile/ui/Button.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useTheme } from './ThemeProvider';
+
+type Props = {
+  title: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+export default function Button({ title, onPress, disabled }: Props) {
+  const { colors, spacing } = useTheme();
+  return (
+    <TouchableOpacity
+      style={[
+        styles.button,
+        { backgroundColor: colors.primary, padding: spacing.m },
+        disabled && { opacity: 0.5 },
+      ]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      <Text style={{ color: colors.text }}>{title}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderRadius: 4,
+    alignItems: 'center',
+  },
+});

--- a/mobile/ui/ThemeProvider.tsx
+++ b/mobile/ui/ThemeProvider.tsx
@@ -1,0 +1,15 @@
+import React, { createContext, useContext } from 'react';
+import { useColorScheme } from 'react-native';
+import { getTheme } from './theme';
+
+type Theme = ReturnType<typeof getTheme>;
+
+const ThemeContext = createContext<Theme>(getTheme());
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const scheme = useColorScheme() ?? 'light';
+  const theme = getTheme(scheme);
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+}

--- a/mobile/ui/index.ts
+++ b/mobile/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as ThemeProvider } from './ThemeProvider';
+export { useTheme } from './ThemeProvider';
+export { default as Button } from './Button';

--- a/mobile/ui/theme.ts
+++ b/mobile/ui/theme.ts
@@ -1,0 +1,37 @@
+import { Appearance } from 'react-native';
+
+export const palette = {
+  light: {
+    background: '#ffffff',
+    text: '#111111',
+    primary: '#6200ee',
+    card: '#f2f2f2',
+  },
+  dark: {
+    background: '#000000',
+    text: '#ffffff',
+    primary: '#bb86fc',
+    card: '#222222',
+  },
+};
+
+export const spacing = {
+  s: 4,
+  m: 8,
+  l: 16,
+  xl: 24,
+};
+
+export const typography = {
+  h1: 32,
+  h2: 24,
+  body: 16,
+};
+
+export function getTheme(scheme: 'light' | 'dark' = Appearance.getColorScheme() || 'light') {
+  return {
+    colors: palette[scheme],
+    spacing,
+    typography,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- introduce a small design system with ThemeProvider and Button
- add bottom tab navigation structure
- hook theme into App root and screens
- create placeholder onboarding flow screens

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*