### PR TITLE
Fix mobile voice package

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,6 +8,6 @@
     "react-native": "0.72.0",
     "expo-router": "^3.0.0",
     "expo-speech": "^10.1.0",
-    "react-native-voice": "^1.1.10"
+    "@react-native-voice/voice": "^3.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- use the namespaced voice package to resolve installation failure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*