### PR TITLE
Fix mobile build dependency

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,6 +8,7 @@
     "react-native": "0.72.0",
     "expo-router": "^3.0.0",
     "expo-speech": "^10.1.0",
-    "react-native-voice": "^1.1.10"
+    "react-native-voice": "^1.1.10",
+    "react-native-big-calendar": "^1.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add missing `react-native-big-calendar` dependency for Android build

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: fastapi)*
- `poetry run ruff check .`