### PR TITLE
Enable GitHub Pages preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Monorepo for the TaskMuse project. It contains the backend API and the React Nat
 The backend exposes a `/healthz` endpoint for health checks and simple
 authentication routes under `/auth`.
 
+
+## GitHub Pages Preview
+
+The contents of the `docs/` folder can be served using GitHub Pages. Navigate to
+**Settings → Pages** in your repository and select `docs/` as the source. After
+a few moments, your documentation will be available at the provided URL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# TaskMuse
+
+This site provides project documentation for TaskMuse.
+
+Refer to the [README](../README.md) for repository setup instructions.
+
+- [Design Overview](DESIGN.md)


### PR DESCRIPTION
## Summary
- add basic index page under `docs/` so GitHub Pages can serve documentation
- document enabling GitHub Pages in README

## Testing
- `git status --short`