### PR TITLE
Enable GitHub Pages website preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Monorepo for the TaskMuse project. It contains the backend API and the React Nat
 The backend exposes a `/healthz` endpoint for health checks and simple
 authentication routes under `/auth`.
 
+
+## GitHub Pages Preview
+
+The contents of the `docs/` folder can be served using GitHub Pages. Navigate to
+**Settings → Pages** in your repository and select `docs/` as the source. After
+a few moments, your documentation will be available at the provided URL.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TaskMuse</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+        header { background: #4a90e2; color: white; padding: 1rem; }
+        main { padding: 1rem; }
+        .sidebar { background: #f4f4f4; width: 200px; float: left; height: 100vh; padding: 1rem; box-sizing: border-box; }
+        .content { margin-left: 220px; }
+        ul { list-style: none; padding: 0; }
+        li { padding: 0.5rem 0; border-bottom: 1px solid #ddd; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>TaskMuse Dashboard</h1>
+    </header>
+    <div class="sidebar">
+        <h3>Navigation</h3>
+        <ul>
+            <li>Dashboard</li>
+            <li>Tasks</li>
+            <li>Account Settings</li>
+        </ul>
+    </div>
+    <div class="content">
+        <main>
+            <h2>Your Tasks</h2>
+            <ul>
+                <li>Design landing page</li>
+                <li>Review pull requests</li>
+                <li>Plan sprint backlog</li>
+            </ul>
+        </main>
+    </div>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# TaskMuse
+
+This site provides project documentation for TaskMuse.
+
+Refer to the [README](../README.md) for repository setup instructions.
+
+- [Design Overview](DESIGN.md)


### PR DESCRIPTION
## Summary
- add simple static index page under `docs/` to preview the website layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/pytz)*